### PR TITLE
build: pin go toolchain to latest patch version for security

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/grafana/xk6-subcommand-example
 
 go 1.25.0
 
+toolchain go1.25.10
+
 require (
 	github.com/spf13/cobra v1.4.0
 	go.k6.io/k6/v2 v2.0.0-rc1


### PR DESCRIPTION
Pin the Go toolchain in go.mod to the latest patch version of the minor it currently targets, picking up the latest security and bugfix releases.